### PR TITLE
Run our own Algolia docsearch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -84,6 +84,12 @@ task build: :all_data do
   Jekyll::Commands::Build.process({})
 end
 
+desc "Serve the site"
+task run: :build do
+  require 'jekyll'
+  Jekyll::Commands::Serve.process({})
+end
+
 desc "Run html proofer to validate the HTML output."
 task html_proofer: :build do
   require "html-proofer"

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: Nodenv's Homebrew package index
 api:
   root: https://nodenv.github.io/formulae
 
-remote_theme: Homebrew/brew.sh
+remote_theme: jasonkarns/brew.sh
 
 exclude:
   - bin

--- a/_layouts/analytics.html
+++ b/_layouts/analytics.html
@@ -1,5 +1,5 @@
 ---
-layout: base
+layout: nodenv_default
 ---
 {%- assign analytics_path = page.dir | split: "/" -%}
 {%- assign analytics_path = analytics_path[1] -%}

--- a/_layouts/analytics_json.json
+++ b/_layouts/analytics_json.json
@@ -1,4 +1,5 @@
 ---
+layout: none
 ---
 {%- assign analytics_path = page.dir | split: "/" -%}
 {%- assign analytics_path = analytics_path[2] -%}

--- a/_layouts/cask.html
+++ b/_layouts/cask.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 permalink: :title
 ---
 {%- assign token = page.title -%}

--- a/_layouts/cask_json.json
+++ b/_layouts/cask_json.json
@@ -1,4 +1,5 @@
 ---
+layout: none
 ---
 {%- assign full_name = page.name | remove: ".json" -%}
 {%- assign name = full_name -%}

--- a/_layouts/formula.html
+++ b/_layouts/formula.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 permalink: :title
 ---
 {%- assign full_name = page.title -%}

--- a/_layouts/formula_json.json
+++ b/_layouts/formula_json.json
@@ -1,4 +1,5 @@
 ---
+layout: none
 ---
 {%- assign formula_path = page.dir | split: "/" -%}
 {%- assign formula_path = formula_path[2] -%}

--- a/_layouts/nodenv_default.html
+++ b/_layouts/nodenv_default.html
@@ -1,0 +1,10 @@
+---
+# base layout from Homebrew/brew.sh theme
+layout: base
+algolia:
+  apiKey: e07da24fca504608d6a9d72caf4363c4
+  indexName: brew_nodenv
+---
+<div id="default">
+  {{ content }}
+</div>

--- a/analytics/index.html
+++ b/analytics/index.html
@@ -1,6 +1,6 @@
 ---
 title: Homebrew Analytics Data
-layout: page
+layout: nodenv_default
 ---
 <h2>macOS</h2>
 

--- a/cask_index.html
+++ b/cask_index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 permalink: /cask/
 ---
 <p>This is a listing of all casks available from the <a href="{{ site.taps.cask.remote }}">{{ site.taps.cask.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ---
 title: JSON API documentation
-layout: page
+layout: nodenv_default
 permalink: /docs/api/
 ---
 ## Formulae

--- a/formula_index.html
+++ b/formula_index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 permalink: /formula/
 ---
 <p>This is a listing of all packages available from the <a href="{{ site.taps.core.remote }}">{{ site.taps.core.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for macOS.</p>

--- a/formula_linux_index.html
+++ b/formula_linux_index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 permalink: /formula-linux/
 ---
 <p>This is a listing of all packages available from the <a href="{{ site.taps.linux.remote }}">{{ site.taps.linux.repo }} tap</a> via the <a href="https://brew.sh">Homebrew</a> package manager for Linux.</p>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: nodenv_default
 ---
 <p><a href="{{ site.baseurl }}/">{{ site.title }}</a> is an online package browser for the <a href="{{ site.taps.core.remote }}">{{ site.taps.core.repo }} tap</a> for <a href="https://brew.sh">Homebrew</a> – the macOS (and Linux) package manager. For more information on how to install and use Homebrew see <a href="https://brew.sh">Homebrew's homepage</a>.</p>
 


### PR DESCRIPTION
In order to run our own docsearch, we need to point the snippet out our index with our apiKey. In order to do that, we need to allow customization of the configuration of that JS snippet.

The main homebrew snippet is "hardcoded" but not in the formulae.brew.sh site (of which this repo is a fork). The docsearch js snippet is hardcoded in the [brew.sh repo](https://github.com/homebrew/brew.sh) here: https://github.com/Homebrew/brew.sh/blob/c10e8fc77a90659d1cce1384fff2edfae39a3a09/_layouts/base.html#L141-L150

So first, we needed to fork brew.sh's theme so that the values could be configured by sites rather then hardcoded. That was done here: https://github.com/Homebrew/brew.sh/blob/c10e8fc77a90659d1cce1384fff2edfae39a3a09/_layouts/base.html#L141-L150

That change makes the algolia configuration set via layout front matter, which can be inherited and overridden by other layouts (in particular, site layouts separate from the remote theme).

Once that was done, we needed to have all the templates within _this_ site use a different base/default template that contained our customized algolia configuration in its front matter: https://github.com/nodenv/formulae/compare/master...nodenv:algolia-docsearch?expand=1#diff-be89cba44122f8374c18eb320a7cceb0

Then all the existing templates and pages were updated to point to our internal default template instead of the remote theme default or base or page.

(also, while we're here, we explicitly set the layout for .json pages to `none` as well as add a rake-run task for serving jekyll locally)