### PR TITLE
Generate analytics data from npm downloads

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "rake"
 require "rake/clean"
-require 'jekyll'
+
+autoload :Jekyll, 'jekyll'
 
 task default: :formula_and_analytics
 

--- a/_data/analytics-npm/download/30d.json
+++ b/_data/analytics-npm/download/30d.json
@@ -1,0 +1,74 @@
+{
+  "category": "download",
+  "total_items": 13,
+  "start_date": "2020-03-23",
+  "end_date": "2020-04-21",
+  "total_count": 2644,
+  "items": [
+    {
+      "package": "@nodenv/jetbrains-npm",
+      "count": 10,
+      "percent": "0.37"
+    },
+    {
+      "package": "@nodenv/node-build-jxcore",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/node-build-prerelease",
+      "count": 3,
+      "percent": "0.11"
+    },
+    {
+      "package": "@nodenv/node-build-update-defs",
+      "count": 2564,
+      "percent": "96.97"
+    },
+    {
+      "package": "@nodenv/nodenv-aliases",
+      "count": 56,
+      "percent": "2.11"
+    },
+    {
+      "package": "@nodenv/nodenv-default-packages",
+      "count": 2,
+      "percent": "0.07"
+    },
+    {
+      "package": "@nodenv/nodenv-each",
+      "count": 2,
+      "percent": "0.07"
+    },
+    {
+      "package": "@nodenv/nodenv-man",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/nodenv-npm-migrate",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/nodenv-package-json-engine",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/nodenv-package-rehash",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/nodenv-update",
+      "count": 1,
+      "percent": "0.03"
+    },
+    {
+      "package": "@nodenv/nodenv-vars",
+      "count": 1,
+      "percent": "0.03"
+    }
+  ]
+}

--- a/_data/analytics-npm/download/365d.json
+++ b/_data/analytics-npm/download/365d.json
@@ -1,0 +1,74 @@
+{
+  "category": "download",
+  "total_items": 13,
+  "start_date": "2019-04-23",
+  "end_date": "2020-04-21",
+  "total_count": 7008,
+  "items": [
+    {
+      "package": "@nodenv/jetbrains-npm",
+      "count": 187,
+      "percent": "2.66"
+    },
+    {
+      "package": "@nodenv/node-build-jxcore",
+      "count": 110,
+      "percent": "1.56"
+    },
+    {
+      "package": "@nodenv/node-build-prerelease",
+      "count": 207,
+      "percent": "2.95"
+    },
+    {
+      "package": "@nodenv/node-build-update-defs",
+      "count": 5492,
+      "percent": "78.36"
+    },
+    {
+      "package": "@nodenv/nodenv-aliases",
+      "count": 127,
+      "percent": "1.81"
+    },
+    {
+      "package": "@nodenv/nodenv-default-packages",
+      "count": 152,
+      "percent": "2.16"
+    },
+    {
+      "package": "@nodenv/nodenv-each",
+      "count": 115,
+      "percent": "1.64"
+    },
+    {
+      "package": "@nodenv/nodenv-man",
+      "count": 79,
+      "percent": "1.12"
+    },
+    {
+      "package": "@nodenv/nodenv-npm-migrate",
+      "count": 108,
+      "percent": "1.54"
+    },
+    {
+      "package": "@nodenv/nodenv-package-json-engine",
+      "count": 77,
+      "percent": "1.09"
+    },
+    {
+      "package": "@nodenv/nodenv-package-rehash",
+      "count": 170,
+      "percent": "2.42"
+    },
+    {
+      "package": "@nodenv/nodenv-update",
+      "count": 109,
+      "percent": "1.55"
+    },
+    {
+      "package": "@nodenv/nodenv-vars",
+      "count": 75,
+      "percent": "1.07"
+    }
+  ]
+}

--- a/_data/analytics-npm/download/90d.json
+++ b/_data/analytics-npm/download/90d.json
@@ -1,0 +1,74 @@
+{
+  "category": "download",
+  "total_items": 13,
+  "start_date": "2020-01-23",
+  "end_date": "2020-04-21",
+  "total_count": 3987,
+  "items": [
+    {
+      "package": "@nodenv/jetbrains-npm",
+      "count": 36,
+      "percent": "0.9"
+    },
+    {
+      "package": "@nodenv/node-build-jxcore",
+      "count": 19,
+      "percent": "0.47"
+    },
+    {
+      "package": "@nodenv/node-build-prerelease",
+      "count": 38,
+      "percent": "0.95"
+    },
+    {
+      "package": "@nodenv/node-build-update-defs",
+      "count": 3679,
+      "percent": "92.27"
+    },
+    {
+      "package": "@nodenv/nodenv-aliases",
+      "count": 71,
+      "percent": "1.78"
+    },
+    {
+      "package": "@nodenv/nodenv-default-packages",
+      "count": 20,
+      "percent": "0.5"
+    },
+    {
+      "package": "@nodenv/nodenv-each",
+      "count": 18,
+      "percent": "0.45"
+    },
+    {
+      "package": "@nodenv/nodenv-man",
+      "count": 17,
+      "percent": "0.42"
+    },
+    {
+      "package": "@nodenv/nodenv-npm-migrate",
+      "count": 18,
+      "percent": "0.45"
+    },
+    {
+      "package": "@nodenv/nodenv-package-json-engine",
+      "count": 17,
+      "percent": "0.42"
+    },
+    {
+      "package": "@nodenv/nodenv-package-rehash",
+      "count": 21,
+      "percent": "0.52"
+    },
+    {
+      "package": "@nodenv/nodenv-update",
+      "count": 17,
+      "percent": "0.42"
+    },
+    {
+      "package": "@nodenv/nodenv-vars",
+      "count": 16,
+      "percent": "0.4"
+    }
+  ]
+}

--- a/rakelib/analytics.rake
+++ b/rakelib/analytics.rake
@@ -1,30 +1,43 @@
-require 'date'
-require 'json'
-require 'pathname'
-require 'open-uri'
+autoload :Date, 'date'
+autoload :DateTime, 'date'
+autoload :JSON, 'json'
+
+require_relative 'ext'
 
 module Analytics
   extend Rake::DSL
 
-  mac_root = %w[_data/analytics]
-  nix_root = %w[_data/analytics-linux]
+  mac_root = "_data/analytics"
+  nix_root = "_data/analytics-linux"
+  npm_root = "_data/analytics-npm"
   periods = %w[30d.json 90d.json 365d.json]
   nix_categories = %w[build-error install install-on-request]
   mac_categories = nix_categories + %w[cask-install]
+  npm_categories = %w[download]
   to_path = ->(ary) { ary.join("/") }
 
-  MAC = mac_root.product(mac_categories, periods).map(&to_path)
-  LINUX = nix_root.product(nix_categories, periods).map(&to_path)
+  MAC = [mac_root].product(mac_categories, periods).map(&to_path)
+  LINUX = [nix_root].product(nix_categories, periods).map(&to_path)
+  NPM = [npm_root].product(npm_categories, periods).map(&to_path)
 
-  API = "https://formulae.brew.sh/api"
-  DIRS = FileList[MAC, LINUX].pathmap('%d')
-  FILE_PATTERN = %r|#{Regexp.union(mac_root + nix_root)}/.*\.json|
+  BREW_API = "https://formulae.brew.sh/api"
+  NPM_API = "https://api.npmjs.org/downloads/point"
+  DIRS = FileList[MAC, LINUX, NPM].pathmap('%d')
+  BREW_FILES = %r|#{Regexp.union(mac_root, nix_root)}/.*\.json|
+  NPM_FILES = %r|#{npm_root}/.*\.json|
+
+  # excludes nodenv-default-npmrc which isn't published to npm
+  PACKAGES = (
+    FileList.new("jetbrains-npm") +
+    FileList.new(%w[jxcore prerelease update-defs]).pathmap("node-build-%p") +
+    FileList.new(%w[aliases default-packages each man npm-migrate package-json-engine package-rehash update vars]).pathmap("nodenv-%p")
+  ).pathmap("@nodenv/%p")
 
   CLOBBER.include DIRS
 
   namespace :data do
     desc "Dump all analytics data"
-    task analytics: %w[analytics:mac analytics:linux]
+    task analytics: %w[analytics:mac analytics:linux analytics:npm]
 
     namespace :analytics do
       desc "Dump mac analytics data"
@@ -33,11 +46,14 @@ module Analytics
       desc "Dump linux analytics data"
       task linux: LINUX
 
+      desc "Dump npm analytics data"
+      task npm: NPM
+
       DIRS.each { |d| directory d }
+      rule Regexp.new BREW_API
+      rule Regexp.new NPM_API
 
-      rule Regexp.new(API)
-
-      rule FILE_PATTERN => ["%{^_data,#{API}}p", "%d"] do |t, args|
+      rule BREW_FILES => ["%{^_data,#{BREW_API}}p", "%d"] do |t, args|
         open(t.name, 'w') do |f|
           f.puts JSON.pretty_generate Rake::Task[t.source].json.tap { |data|
             data["items"].select! { |i| i["formula"] =~ %r{^nodenv/} }
@@ -48,42 +64,58 @@ module Analytics
           }
         end
       end
+
+      period = "{30d,last-month;90d,#{Date.today.prev_day(90)}:#{Date.today.prev_day};365d,last-year}"
+      rule NPM_FILES => [*PACKAGES.pathmap("#{NPM_API}/%%#{period}n/%p"), "%d"] do |t|
+        packages = t.prerequisite_tasks.select{ |t| Rake::JsonFile === t}.map(&:json)
+        total = packages.reduce(0) { |sum, p| sum + p["downloads"] }
+
+        open(t.name, 'w') do |f|
+          f.puts JSON.pretty_generate({
+            category: "download",
+            total_items: packages.size,
+            start_date: packages.first["start"],
+            end_date: packages.first["end"],
+            total_count: total,
+            items: packages.map { |p| {
+              package: p["package"],
+              count: p["downloads"],
+              percent: (p["downloads"].to_f / total * 100).truncate(2).to_s
+            } }
+          })
+        end
+      end
     end
   end
 
   class JsonFileTask < Rake::FileTask
+    include Rake::JsonFile
+
     def timestamp
-      JSON.load(Pathname.new name)["end_date"].then { |dt|
-        DateTime.parse(dt).next_day.to_time } rescue Rake::LATE
+      DateTime.parse(json["end_date"]).next_day.to_time
     end
   end
-end
 
-class HttpResourceTask < Rake::FileTask
-  def read
-    resource.read
+  class NpmApiTask < Rake::HttpResourceTask
+    include Rake::JsonFile
+
+    def timestamp
+      DateTime.parse(json["end"]).next_day.to_time || super
+    end
   end
 
-  def timestamp
-    resource.last_modified
-  end
-
-  def json
-    JSON.load read
-  end
-
-  private
-
-  def resource
-    @resource ||= URI(name).open
+  class BrewApiTask < Rake::HttpResourceTask
+    include Rake::JsonFile
   end
 end
 
 class Rake::FileTask
   def self.define_task(name, *args, &block)
     task_class = case name
-    when Analytics::FILE_PATTERN then Analytics::JsonFileTask
-    when Regexp.new(Analytics::API) then HttpResourceTask
+    when Analytics::BREW_FILES then Analytics::JsonFileTask
+    when Analytics::NPM_FILES then Analytics::JsonFileTask
+    when Regexp.new(Analytics::BREW_API) then Analytics::BrewApiTask
+    when Regexp.new(Analytics::NPM_API) then Analytics::NpmApiTask
     else self
     end
     Rake.application.define_task(task_class, name, *args, &block)

--- a/rakelib/analytics.rake
+++ b/rakelib/analytics.rake
@@ -67,7 +67,7 @@ module Analytics
 
       period = "{30d,last-month;90d,#{Date.today.prev_day(90)}:#{Date.today.prev_day};365d,last-year}"
       rule NPM_FILES => [*PACKAGES.pathmap("#{NPM_API}/%%#{period}n/%p"), "%d"] do |t|
-        packages = t.prerequisite_tasks.select{ |t| Rake::JsonFile === t}.map(&:json)
+        packages = t.prerequisite_tasks.grep(Rake::JsonFile, &:json)
         total = packages.reduce(0) { |sum, p| sum + p["downloads"] }
 
         open(t.name, 'w') do |f|

--- a/rakelib/analytics.rake
+++ b/rakelib/analytics.rake
@@ -41,6 +41,10 @@ module Analytics
         open(t.name, 'w') do |f|
           f.puts JSON.pretty_generate Rake::Task[t.source].json.tap { |data|
             data["items"].select! { |i| i["formula"] =~ %r{^nodenv/} }
+
+            data["total_items"] = data["items"].size
+            data["total_count"] = data["items"].reduce(0) { |sum, i| sum + i["count"].to_i}
+            data["items"].each{ |i| i["percent"] = (i["count"].to_f / data["total_count"] * 100).truncate(2).to_s }
           }
         end
       end

--- a/rakelib/analytics.rake
+++ b/rakelib/analytics.rake
@@ -14,15 +14,14 @@ module Analytics
   nix_categories = %w[build-error install install-on-request]
   mac_categories = nix_categories + %w[cask-install]
   npm_categories = %w[download]
-  to_path = ->(ary) { ary.join("/") }
 
-  MAC = [mac_root].product(mac_categories, periods).map(&to_path)
-  LINUX = [nix_root].product(nix_categories, periods).map(&to_path)
-  NPM = [npm_root].product(npm_categories, periods).map(&to_path)
+  MAC = [mac_root].product(mac_categories, periods).map{ |a| a.join("/") }
+  NIX = [nix_root].product(nix_categories, periods).map{ |a| a.join("/") }
+  NPM = [npm_root].product(npm_categories, periods).map{ |a| a.join("/") }
 
   BREW_API = "https://formulae.brew.sh/api"
   NPM_API = "https://api.npmjs.org/downloads/point"
-  DIRS = FileList[MAC, LINUX, NPM].pathmap('%d')
+  DIRS = FileList[MAC, NIX, NPM].pathmap('%d')
   BREW_FILES = %r|#{Regexp.union(mac_root, nix_root)}/.*\.json|
   NPM_FILES = %r|#{npm_root}/.*\.json|
 
@@ -44,7 +43,7 @@ module Analytics
       task mac: MAC
 
       desc "Dump linux analytics data"
-      task linux: LINUX
+      task linux: NIX
 
       desc "Dump npm analytics data"
       task npm: NPM

--- a/rakelib/ext.rb
+++ b/rakelib/ext.rb
@@ -1,0 +1,43 @@
+autoload :JSON, 'json'
+autoload :OpenURI, 'open-uri'
+autoload :Pathname, 'pathname'
+
+module Rake
+  class FileTask
+    def to_path
+      Pathname.new name
+    end
+
+    def read
+      to_path.read
+    end
+  end
+
+  module JsonFile
+    def json
+      JSON.load self
+    end
+  end
+
+  class HttpResourceTask < Rake::FileTask
+    def read
+      resource.read
+    end
+
+    def timestamp
+      resource.last_modified || Rake::LATE
+    end
+
+    private
+
+    def resource
+      return @resource if defined? @resource
+      Rake.rake_output_message "get #{name}" if verbose?
+      @resource = OpenURI.open_uri(name)
+    end
+
+    def verbose?
+      (FileUtilsExt.verbose_flag == FileUtilsExt::DEFAULT) || FileUtilsExt.verbose_flag
+    end
+  end
+end

--- a/rakelib/ext.rb
+++ b/rakelib/ext.rb
@@ -15,13 +15,13 @@ module Rake
 
   module JsonFile
     def json
-      JSON.load self
+      @json ||= JSON.load self
     end
   end
 
   class HttpResourceTask < Rake::FileTask
     def read
-      resource.read
+      @read ||= resource.read
     end
 
     def timestamp


### PR DESCRIPTION
Generic Rake extensions:

- Extends rake's FileTask to be an IO-readable. (and Pathname-able)
- Extracts logic for any task to represent a JSON file (can be included
  in any IO-readable)
- Defines HttpResourceTask to be an IO-readable with an HTTP-specific
  definition for its timestamp

Extracted Analytics-specific classes:
- JsonFileTask's timestamp is dependent on an internal property (unique
  to homebrew's analytics json structure)
- NpmApiTask is an HttpResourceTask for JSON resources but needs a
  custom timestamp because the api doesn't provide Last-Modified header
- BrewApiTask is an HttpResourceTask that represents JSON resources

Also includes initial scrape of npm data and bugfix for homebrew's analytics.

This is step 1 for #9 

Also for reference: https://github.com/npm/registry/blob/master/docs/download-counts.md